### PR TITLE
check for `wget`, `bagit.py` before running (#4)

### DIFF
--- a/bagweb
+++ b/bagweb
@@ -1,6 +1,15 @@
 #!/bin/bash
 
-# TODO: make sure wget and bagit.py are installed
+# make sure wget and bagit.py are installed
+command -v -- wget >/dev/null 2>&1 || {
+  echo "wget is required but is not installed. Aborting." >&2
+  exit 1
+}
+pip show -- bagit >/dev/null 2>&1 ||
+pip3 show -- bagit >/dev/null 2>&1 || {
+  echo "bagit.py is required but is not installed. Aborting." >&2
+  exit 1
+}
 
 url=$1
 name=$2


### PR DESCRIPTION
bagweb doesn’t first check if both `wget` and `bagit.py` are installed before trying to run them:
https://github.com/edsu/bagweb/blob/62e4d0625d634bc0ff289f417d3169b1a66f9c7f/bagweb#L3

This pull request to add those verifications – including checks for `bagit` via both `pip` and `pip3` – will fix #4.